### PR TITLE
#add: PGroonga拡張を追加、cwも検索対象に

### DIFF
--- a/Dockerfile-pg
+++ b/Dockerfile-pg
@@ -1,0 +1,20 @@
+FROM postgres:15-bookworm
+
+ENV PGROONGA_VERSION=3.1.1-1
+RUN \
+    apt update && \
+    apt install -y -V wget && \
+    wget https://apache.jfrog.io/artifactory/arrow/debian/apache-arrow-apt-source-latest-bookworm.deb && \
+    apt install -y -V ./apache-arrow-apt-source-latest-bookworm.deb && \
+    rm apache-arrow-apt-source-latest-bookworm.deb && \
+    wget https://packages.groonga.org/debian/groonga-apt-source-latest-bookworm.deb && \
+    apt install -y -V ./groonga-apt-source-latest-bookworm.deb && \
+    rm groonga-apt-source-latest-bookworm.deb && \
+    apt update && \
+    apt install -y -V \
+    postgresql-15-pgdg-pgroonga=${PGROONGA_VERSION} \
+    groonga-normalizer-mysql \
+    groonga-token-filter-stem \
+    groonga-tokenizer-mecab && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/*

--- a/packages/backend/migration/1691850149834-AddPgroongaIndexes.js
+++ b/packages/backend/migration/1691850149834-AddPgroongaIndexes.js
@@ -1,0 +1,10 @@
+export class AddPgroongaIndexes1691850149834 {
+    name = 'AddPgroongaIndexes1691850149834'
+    async up(queryRunner) {
+        await queryRunner.query(`CREATE EXTENSION IF NOT EXISTS pgroonga;`);
+        await queryRunner.query(`CREATE INDEX idx_note_text_cw_pgroonga ON note USING pgroonga(text, cw);`);
+    }
+    async down(queryRunner) {
+        await queryRunner.query(`DROP INDEX idx_note_text_cw_pgroonga;`);
+    }
+}

--- a/packages/backend/src/core/SearchService.ts
+++ b/packages/backend/src/core/SearchService.ts
@@ -43,8 +43,8 @@ function compileQuery(q: Q): string {
 		case '<': return `(${q.k} < ${compileValue(q.v)})`;
 		case '>=': return `(${q.k} >= ${compileValue(q.v)})`;
 		case '<=': return `(${q.k} <= ${compileValue(q.v)})`;
-		case 'and': return q.qs.length === 0 ? '' : `(${ q.qs.map(_q => compileQuery(_q)).join(' AND ') })`;
-		case 'or': return q.qs.length === 0 ? '' : `(${ q.qs.map(_q => compileQuery(_q)).join(' OR ') })`;
+		case 'and': return q.qs.length === 0 ? '' : `(${q.qs.map(_q => compileQuery(_q)).join(' AND ')})`;
+		case 'or': return q.qs.length === 0 ? '' : `(${q.qs.map(_q => compileQuery(_q)).join(' OR ')})`;
 		case 'not': return `(NOT ${compileQuery(q.q)})`;
 		default: throw new Error('unrecognized query operator');
 	}
@@ -192,7 +192,7 @@ export class SearchService {
 			}
 
 			query
-				.andWhere('note.text ILIKE :q', { q: `%${ sqlLikeEscape(q) }%` })
+				.andWhere('(note.text &@~ :q OR note.cw &@~ :q)', { q: q }) // PGroonga
 				.innerJoinAndSelect('note.user', 'user')
 				.leftJoinAndSelect('note.reply', 'reply')
 				.leftJoinAndSelect('note.renote', 'renote')

--- a/packages/backend/src/models/entities/Note.ts
+++ b/packages/backend/src/models/entities/Note.ts
@@ -9,6 +9,9 @@ import type { DriveFile } from './DriveFile.js';
 @Index('IDX_NOTE_TAGS', { synchronize: false })
 @Index('IDX_NOTE_MENTIONS', { synchronize: false })
 @Index('IDX_NOTE_VISIBLE_USER_IDS', { synchronize: false })
+// PGroongaのインデックス追加
+@Entity('note')
+@Index('idx_note_text_cw_pgroonga', ['text', 'cw'], { using: 'pgroonga' })
 export class Note {
 	@PrimaryColumn(id())
 	public id: string;


### PR DESCRIPTION
## What
- PGroonga拡張を追加したPostgreSQLのDockerfileを追加
- DBへPGroonga拡張の追加
- PGroonga用インデックス作成のDBマイグレーションファイルの追加
- 検索対象をnote.textとnote.cwに

## Why
Meilisearchに頼らずAND/OR/NOT検索がした

## Additional info (optional)
note.textとnote.cwに跨がったAND検索は今回の書き換えではできないのでいずれできるようにしたい