### PR TITLE
#add: pg_rmanで定期自動実行バックアップ

### DIFF
--- a/Dockerfile-pg
+++ b/Dockerfile-pg
@@ -18,3 +18,32 @@ RUN \
     groonga-tokenizer-mecab && \
     apt clean && \
     rm -rf /var/lib/apt/lists/*
+
+# pg_rman install
+RUN apt update
+RUN apt install -y build-essential libpq-dev git zlib1g-dev
+RUN apt-get update
+RUN apt-get -y install postgresql-client-15 postgresql-15 postgresql-server-dev-15 libpq-dev
+RUN apt-get -y install libpq-dev libselinux1-dev liblz4-dev libpam0g-dev libkrb5-dev libreadline-dev libzstd-dev
+
+RUN git clone https://github.com/ossc-db/pg_rman.git /tmp/pg_rman && \
+    cd /tmp/pg_rman && \
+    make && make install && \
+    rm -rf /tmp/pg_rman
+
+# backup script
+RUN apt-get update && apt-get install -y cron
+
+COPY pgrman_scripts/backup_script.sh /usr/local/bin/backup_script.sh
+COPY pgrman_scripts/start.sh /usr/local/bin/start.sh
+RUN chmod +x /usr/local/bin/backup_script.sh
+RUN chmod +x /usr/local/bin/start.sh
+
+RUN echo "0 2 * * * /usr/local/bin/backup_script.sh full" > /etc/crontab
+RUN echo "0 */2 * * * /usr/local/bin/backup_script.sh incremental" >> /etc/crontab
+
+# バックアップスクリプトの自動実行は
+# sudo docker exec -it コンテナ名 /usr/local/bin/start.sh start 
+# で開始、引数stopで終了できる
+
+CMD ["docker-entrypoint.sh", "postgres"]

--- a/pgrman_scripts/backup_script.sh
+++ b/pgrman_scripts/backup_script.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+BACKUP_DIR="/var/lib/postgresql/backup"
+DB_DIR="/var/lib/postgresql/data"
+ARCHIVE_DIR="/var/lib/postgresql/archive"
+MODE="$1"
+
+/usr/pgsql-15/bin/pg_rman backup --backup-mode=$MODE -b $BACKUP_DIR -D $DB_DIR -A $ARCHIVE_DIR

--- a/pgrman_scripts/start.sh
+++ b/pgrman_scripts/start.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+case "$1" in
+  start)
+    cron
+    ;;
+  stop)
+    service cron stop
+    ;;
+  *)
+    echo "Usage: $0 {start|stop}"
+    exit 1
+esac


### PR DESCRIPTION
## What
- PostgreSQLのDockerfileにpg_rmanのインストールを追加
- 自動バックアップスクリプト(backup_script.sh)の作成
  - とりあえず1日1回フルバックアップ&2時間に1回差分バックアップを取る仕様
- 定期自動実行のオンオフができるようにした
  - `sudo docker exec -it コンテナ名 start.sh start` // 定期自動実行オン
  - `sudo docker exec -it コンテナ名 start.sh stop` // 定期自動実行オフ

## Why
バックアップで楽をしたい

## Additional info (optional)
Dockerコンテナ内でバックアップを取る形なので、これを外部ストレージと自動同期させるスクリプトを別途書く
