### PR TITLE
#add: rcloneでバックアップファイルをOnedriveに自動同期

### DIFF
--- a/Dockerfile-pg
+++ b/Dockerfile-pg
@@ -1,5 +1,6 @@
 FROM postgres:15-bookworm
 
+# PGroonga install
 ENV PGROONGA_VERSION=3.1.1-1
 RUN \
     apt update && \
@@ -45,5 +46,14 @@ RUN echo "0 */2 * * * /usr/local/bin/backup_script.sh incremental" >> /etc/cront
 # バックアップスクリプトの自動実行は
 # sudo docker exec -it コンテナ名 /usr/local/bin/start.sh start 
 # で開始、引数stopで終了できる
+
+# rclone install
+# ホストOSでrclone configしてrclone.confを作成しておき、
+# docker-compose.yamlのDBのvolumeに
+# `- /ホストOSのrclone設定ファイルの場所/rclone.conf:/root/.config/rclone/rclone.conf `を追加しておく
+# ...
+RUN apt update && \
+    apt install -y curl unzip && \
+    curl https://rclone.org/install.sh | bash
 
 CMD ["docker-entrypoint.sh", "postgres"]

--- a/pgrman_scripts/backup_script.sh
+++ b/pgrman_scripts/backup_script.sh
@@ -4,5 +4,17 @@ BACKUP_DIR="/var/lib/postgresql/backup"
 DB_DIR="/var/lib/postgresql/data"
 ARCHIVE_DIR="/var/lib/postgresql/archive"
 MODE="$1"
+RCLONE_REMOTE="onedrive"  # rcloneリモート名
+RCLONE_PATH="server/backup/misskey"  # 保存先のOneDriveフォルダのパス
 
+# rcloneの設定ファイルの場所を指定
+export RCLONE_CONFIG="/root/.config/rclone/rclone.conf"
+
+# pg_rmanバックアップを実行
 /usr/pgsql-15/bin/pg_rman backup --backup-mode=$MODE -b $BACKUP_DIR -D $DB_DIR -A $ARCHIVE_DIR
+
+# バックアップを検証
+/usr/pgsql-15/bin/pg_rman validate -b $BACKUP_DIR -D $DB_DIR -A $ARCHIVE_DIR
+
+# rcloneでOneDriveにアップロード
+rclone sync $BACKUP_DIR $RCLONE_REMOTE:$RCLONE_PATH


### PR DESCRIPTION
## What
- PostgreSQLのDockerfileにrcloneインストールを追加
- バックアップスクリプトにバックアップ作成&検証後rcloneを使用しOnedriveへの自動同期を追加

## Why
- シングルサーバーだといつ爆発するかわからないので…
- バーチャルコネクトのせいで自宅鯖にrsyncできない

## Additional info (optional)
先にホストOSなどでrcloneの設定ファイルrclone.confを作成して配置しておくこと

